### PR TITLE
fix: validate process.pid value

### DIFF
--- a/lib/processMonitor.js
+++ b/lib/processMonitor.js
@@ -23,6 +23,9 @@ module.exports.getPsInfo = getPsInfo;
 function getPsInfo(param, callback) { 
 	if (process.platform === 'windows') return;
 	var pid = param.pid;
+	if (typeof pid !== "number") {
+        console.log('pid must be a number!');
+    } else {
 	var cmd = "ps auxw | grep " + pid + " | grep -v 'grep'";
 	//var cmd = "ps auxw | grep -E '.+?\\s+" + pid + "\\s+'"  ;
 	exec(cmd, function(err, output) {
@@ -37,6 +40,7 @@ function getPsInfo(param, callback) {
 		} 
     format(param, output, callback);
 	});
+}
 };
 
 /**


### PR DESCRIPTION
The PID value given to cmd should always be a number `console.log(typeof process.pid);` . This PR validates that and prevents command injection.