### PR TITLE
Update processMonitor.js for RCE

### DIFF
--- a/lib/processMonitor.js
+++ b/lib/processMonitor.js
@@ -23,6 +23,9 @@ module.exports.getPsInfo = getPsInfo;
 function getPsInfo(param, callback) { 
 	if (process.platform === 'windows') return;
 	var pid = param.pid;
+	if (typeof pid !== "number") {
+        throw new Error("pid must be a number");
+        }
 	var cmd = "ps auxw | grep " + pid + " | grep -v 'grep'";
 	//var cmd = "ps auxw | grep -E '.+?\\s+" + pid + "\\s+'"  ;
 	exec(cmd, function(err, output) {


### PR DESCRIPTION
Tested: node poc.js 
/apps/poc/node_modules/pomelo-monitor/lib/processMonitor.js:28
        throw new Error("pid must be a number");
        ^

Error: pid must be a number